### PR TITLE
Update to match NXP SDK 24.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+libg2d-dpu (2.2.0-1) bookworm; urgency=medium
+
+  * Team upload.
+  * New upstream release 2.2.0-7943590.
+  * d/libg2d-dpu.links: update symlink to match newer library version.
+  * d/libg2d-dpu.symbols: add symbols from new release.
+
+ -- Carlos Henrique Lima Melara <carlos.melara@toradex.com>  Mon, 27 Jan 2025 12:56:47 -0300
+
 libg2d-dpu (2.1.14-1) bookworm; urgency=medium
 
   * Team upload.

--- a/debian/libg2d-dpu.links
+++ b/debian/libg2d-dpu.links
@@ -1,1 +1,1 @@
-usr/lib/${DEB_HOST_GNU_TYPE}/libg2d-dpu.so.2.1.0 usr/lib/${DEB_HOST_GNU_TYPE}/libg2d-dpu.so.2
+usr/lib/${DEB_HOST_GNU_TYPE}/libg2d-dpu.so.2.2.0 usr/lib/${DEB_HOST_GNU_TYPE}/libg2d-dpu.so.2

--- a/debian/libg2d-dpu.symbols
+++ b/debian/libg2d-dpu.symbols
@@ -14,6 +14,7 @@ libg2d.so.2 libg2d
  DpuDisableSourceGlobalAlpha@Base 2.1.2
  DpuDisableSourcePremul@Base 2.1.2
  DpuDisableStretch@Base 2.1.2
+ DpuDisableWarp@Base 2.2.0
  DpuDispatch@Base 2.1.2
  DpuEnableAlphaBlend@Base 2.1.2
  DpuEnableCscMatrix@Base 2.1.2
@@ -90,6 +91,7 @@ libg2d.so.2 libg2d
  g2d_opencl_conversion@Base 2.1.2
  g2d_query_cap@Base 2.1.2
  g2d_query_feature@Base 2.1.2
+ g2d_query_hardware@Base 2.2.0
  g2d_set_clipping@Base 2.1.2
  g2d_set_csc_matrix@Base 2.1.2
  g2d_set_warp_coordinates@Base 2.1.2

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 
 # export DH_VERBOSE=1
 
-FILENAME="imx-dpu-g2d-v1-2.1.14-6a00326"
+FILENAME="imx-dpu-g2d-v1-2.2.0-7943590"
 URL="https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/$(FILENAME).bin"
 
 %:


### PR DESCRIPTION
I've tested this on Apalis iMX8QP and there is a weird thing in the log:

```
[15:04:31.122] Loading module '/usr/lib/aarch64-linux-gnu/libweston-12/g2d-renderer.so'
CreateKernel failed to create read_row_of_tiles:  -6
g2d_init_openclFailed creating kernel_read_row

```

I searched as much as I could, and there is no indication g2d is not being used because of this error and weston runs fine. Also, no one in NXP's forums complaining about this and libg2d is a binary blob we can't debug.